### PR TITLE
Updated tracker to version 3.0 and added consent mode

### DIFF
--- a/classes/PiwikTracker.php
+++ b/classes/PiwikTracker.php
@@ -1,31 +1,30 @@
 <?php namespace Acte\MatomoPhpTracker\Classes;
-
 /**
- * Piwik - free/libre analytics platform
+ * Matomo - free/libre analytics platform
  *
  * For more information, see README.md
  *
  * @license released under BSD License http://www.opensource.org/licenses/bsd-license.php
- * @link http://piwik.org/docs/tracking-api/
+ * @link https://matomo.org/docs/tracking-api/
  *
- * @category Piwik
- * @package PiwikTracker
+ * @category Matomo
+ * @package MatomoTracker
  */
 
 /**
- * PiwikTracker implements the Piwik Tracking Web API.
+ * MatomoTracker implements the Matomo Tracking Web API.
  *
- * For more information, see README.md
+ * For more information, see: https://github.com/matomo-org/matomo-php-tracker/
  *
- * @package PiwikTracker
+ * @package MatomoTracker
  * @api
  */
 class PiwikTracker
 {
     /**
-     * Piwik base URL, for example http://example.org/piwik/
+     * Matomo base URL, for example http://example.org/matomo/
      * Must be set before using the class by calling
-     * PiwikTracker::$URL = 'http://yourwebsite.org/piwik/';
+     * MatomoTracker::$URL = 'http://yourwebsite.org/matomo/';
      *
      * @var string
      */
@@ -59,17 +58,9 @@ class PiwikTracker
     const DEFAULT_CHARSET_PARAMETER_VALUES = 'utf-8';
 
     /**
-     * See piwik.js
+     * See matomo.js
      */
     const FIRST_PARTY_COOKIES_PREFIX = '_pk_';
-
-    /**
-     * Ecommerce item page view tracking stores item's metadata in these Custom Variables slots.
-     */
-    const CVAR_INDEX_ECOMMERCE_ITEM_PRICE = 2;
-    const CVAR_INDEX_ECOMMERCE_ITEM_SKU = 3;
-    const CVAR_INDEX_ECOMMERCE_ITEM_NAME = 4;
-    const CVAR_INDEX_ECOMMERCE_ITEM_CATEGORY = 5;
 
     /**
      * Defines how many categories can be used max when calling addEcommerceItem().
@@ -79,13 +70,15 @@ class PiwikTracker
 
     const DEFAULT_COOKIE_PATH = '/';
 
+    private $requestMethod = null;
+
     /**
-     * Builds a PiwikTracker object, used to track visits, pages and Goal conversions
-     * for a specific website, by using the Piwik Tracking API.
+     * Builds a MatomoTracker object, used to track visits, pages and Goal conversions
+     * for a specific website, by using the Matomo Tracking API.
      *
      * @param int $idSite Id site to be tracked
-     * @param string $apiUrl "http://example.org/piwik/" or "http://piwik.example.org/"
-     *                         If set, will overwrite PiwikTracker::$URL
+     * @param string $apiUrl "http://example.org/matomo/" or "http://matomo.example.org/"
+     *                         If set, will overwrite MatomoTracker::$URL
      */
     public function __construct($idSite, $apiUrl = '')
     {
@@ -94,9 +87,16 @@ class PiwikTracker
         $this->eventCustomVar = false;
         $this->forcedDatetime = false;
         $this->forcedNewVisit = false;
-        $this->generationTime = false;
+        $this->networkTime = false;
+        $this->serverTime = false;
+        $this->transferTime = false;
+        $this->domProcessingTime = false;
+        $this->domCompletionTime = false;
+        $this->onLoadTime = false;
         $this->pageCustomVar = false;
+        $this->ecommerceView = array();
         $this->customParameters = array();
+        $this->customDimensions = array();
         $this->customData = false;
         $this->hasCookies = false;
         $this->token_auth = false;
@@ -143,13 +143,12 @@ class PiwikTracker
         $this->configCookiesDisabled = false;
         $this->configCookiePath = self::DEFAULT_COOKIE_PATH;
         $this->configCookieDomain = '';
+        $this->configCookieSameSite = '';
+        $this->configCookieSecure = false;
+        $this->configCookieHTTPOnly = false;
 
         $this->currentTs = time();
         $this->createTs = $this->currentTs;
-        $this->visitCount = 0;
-        $this->currentVisitTs = false;
-        $this->lastVisitTs = false;
-        $this->ecommerceLastOrderTimestamp = false;
 
         // Allow debug while blocking the request
         $this->requestTimeout = 600;
@@ -165,9 +164,9 @@ class PiwikTracker
     }
 
     /**
-     * By default, Piwik expects utf-8 encoded values, for example
+     * By default, Matomo expects utf-8 encoded values, for example
      * for the page URL parameter values, Page Title, etc.
-     * It is recommended to only send UTF-8 data to Piwik.
+     * It is recommended to only send UTF-8 data to Matomo.
      * If required though, you can also specify another charset using this function.
      *
      * @param string $charset
@@ -208,11 +207,49 @@ class PiwikTracker
      *
      * @param int $timeMs Generation time in ms
      * @return $this
+     *
+     * @deprecated this metric is deprecated please use performance timings instead
+     * @see setPerformanceTimings
      */
     public function setGenerationTime($timeMs)
     {
-        $this->generationTime = $timeMs;
         return $this;
+    }
+
+    /**
+     * Sets timings for various browser performance metrics.
+     * @see https://developer.mozilla.org/en-US/docs/Web/API/PerformanceTiming
+     *
+     * @param null|int $network Network time in ms (connectEnd – fetchStart)
+     * @param null|int $server Server time in ms (responseStart – requestStart)
+     * @param null|int $transfer Transfer time in ms (responseEnd – responseStart)
+     * @param null|int $domProcessing DOM Processing to Interactive time in ms (domInteractive – domLoading)
+     * @param null|int $domCompletion DOM Interactive to Complete time in ms (domComplete – domInteractive)
+     * @param null|int $onload Onload time in ms (loadEventEnd – loadEventStart)
+     * @return $this
+     */
+    public function setPerformanceTimings($network = null, $server = null, $transfer = null, $domProcessing = null, $domCompletion = null, $onload = null)
+    {
+        $this->networkTime = $network;
+        $this->serverTime = $server;
+        $this->transferTime = $transfer;
+        $this->domProcessingTime = $domProcessing;
+        $this->domCompletionTime = $domCompletion;
+        $this->onLoadTime = $onload;
+        return $this;
+    }
+
+    /**
+     * Clear / reset all previously set performance metrics.
+     */
+    public function clearPerformanceTimings()
+    {
+        $this->networkTime = false;
+        $this->serverTime = false;
+        $this->transferTime = false;
+        $this->domProcessingTime = false;
+        $this->domCompletionTime = false;
+        $this->onLoadTime = false;
     }
 
     /**
@@ -230,7 +267,7 @@ class PiwikTracker
      * properly attributed to the right Referrer URL, timestamp, Campaign Name & Keyword.
      *
      * This must be a JSON encoded string that would typically be fetched from the JS API:
-     * piwikTracker.getAttributionInfo() and that you have JSON encoded via JSON2.stringify()
+     * matomoTracker.getAttributionInfo() and that you have JSON encoded via JSON2.stringify()
      *
      * If you call enableCookies() then these referral attribution values will be set
      * to the 'ref' first party cookie storing referral information.
@@ -238,7 +275,7 @@ class PiwikTracker
      * @param string $jsonEncoded JSON encoded array containing Attribution info
      * @return $this
      * @throws Exception
-     * @see function getAttributionInfo() in https://github.com/piwik/piwik/blob/master/js/piwik.js
+     * @see function getAttributionInfo() in https://github.com/matomo-org/matomo/blob/master/js/matomo.js
      */
     public function setAttributionInfo($jsonEncoded)
     {
@@ -252,7 +289,7 @@ class PiwikTracker
 
     /**
      * Sets Visit Custom Variable.
-     * See http://piwik.org/docs/custom-variables/
+     * See https://matomo.org/docs/custom-variables/
      *
      * @param int $id Custom variable slot ID from 1-5
      * @param string $name Custom variable name
@@ -281,7 +318,7 @@ class PiwikTracker
     /**
      * Returns the currently assigned Custom Variable.
      *
-     * If scope is 'visit', it will attempt to read the value set in the first party cookie created by Piwik Tracker
+     * If scope is 'visit', it will attempt to read the value set in the first party cookie created by Matomo Tracker
      *  ($_COOKIE array).
      *
      * @param int $id Custom Variable integer index to fetch from cookie. Should be a value from 1 to 5
@@ -289,7 +326,7 @@ class PiwikTracker
      *
      * @throws Exception
      * @return mixed An array with this format: array( 0 => CustomVariableName, 1 => CustomVariableValue ) or false
-     * @see Piwik.js getCustomVariable()
+     * @see matomo.js getCustomVariable()
      */
     public function getCustomVariable($id, $scope = 'visit')
     {
@@ -334,17 +371,56 @@ class PiwikTracker
     }
 
     /**
+     * Sets a specific custom dimension
+     *
+     * @param int $id id of custom dimension
+     * @param string $value value for custom dimension
+     * @return $this
+     */
+    public function setCustomDimension($id, $value)
+    {
+        $this->customDimensions['dimension'.(int)$id] = $value;
+        return $this;
+    }
+
+    /**
+     * Clears all previously set custom dimensions
+     */
+    public function clearCustomDimensions()
+    {
+        $this->customDimensions = [];
+    }
+
+    /**
+     * Returns the value of the custom dimension with the given id
+     *
+     * @param int $id id of custom dimension
+     * @return string|null
+     */
+    public function getCustomDimension($id)
+    {
+        return $this->customDimensions['dimension'.(int)$id] ?? null;
+    }
+
+    /**
      * Sets a custom tracking parameter. This is useful if you need to send any tracking parameters for a 3rd party
-     * plugin that is not shipped with Piwik itself. Please note that custom parameters are cleared after each
+     * plugin that is not shipped with Matomo itself. Please note that custom parameters are cleared after each
      * tracking request.
      *
-     * @param string $trackingApiParameter The name of the tracking API parameter, eg 'dimension1'
+     * @param string $trackingApiParameter The name of the tracking API parameter, eg 'bw_bytes'
      * @param string $value Tracking parameter value that shall be sent for this tracking parameter.
      * @return $this
      * @throws Exception
      */
     public function setCustomTrackingParameter($trackingApiParameter, $value)
     {
+        $matches = [];
+
+        if (preg_match('/^dimension([0-9]+)$/', $trackingApiParameter, $matches)) {
+            $this->setCustomDimension($matches[1], $value);
+            return $this;
+        }
+
         $this->customParameters[$trackingApiParameter] = $value;
         return $this;
     }
@@ -364,7 +440,6 @@ class PiwikTracker
     public function setNewVisitorId()
     {
         $this->randomVisitorId = substr(md5(uniqid(rand(), true)), 0, self::LENGTH_VISITOR_ID);
-        $this->userId = false;
         $this->forcedVisitorId = false;
         $this->cookieVisitorId = false;
         return $this;
@@ -408,7 +483,7 @@ class PiwikTracker
     }
 
     /**
-     * Sets the country of the visitor. If not used, Piwik will try to find the country
+     * Sets the country of the visitor. If not used, Matomo will try to find the country
      * using either the visitor's IP address or language.
      *
      * Allowed only for Admin/Super User, must be used along with setTokenAuth().
@@ -422,7 +497,7 @@ class PiwikTracker
     }
 
     /**
-     * Sets the region of the visitor. If not used, Piwik may try to find the region
+     * Sets the region of the visitor. If not used, Matomo may try to find the region
      * using the visitor's IP address (if configured to do so).
      *
      * Allowed only for Admin/Super User, must be used along with setTokenAuth().
@@ -436,7 +511,7 @@ class PiwikTracker
     }
 
     /**
-     * Sets the city of the visitor. If not used, Piwik may try to find the city
+     * Sets the city of the visitor. If not used, Matomo may try to find the city
      * using the visitor's IP address (if configured to do so).
      *
      * Allowed only for Admin/Super User, must be used along with setTokenAuth().
@@ -450,7 +525,7 @@ class PiwikTracker
     }
 
     /**
-     * Sets the latitude of the visitor. If not used, Piwik may try to find the visitor's
+     * Sets the latitude of the visitor. If not used, Matomo may try to find the visitor's
      * latitude using the visitor's IP address (if configured to do so).
      *
      * Allowed only for Admin/Super User, must be used along with setTokenAuth().
@@ -464,7 +539,7 @@ class PiwikTracker
     }
 
     /**
-     * Sets the longitude of the visitor. If not used, Piwik may try to find the visitor's
+     * Sets the longitude of the visitor. If not used, Matomo may try to find the visitor's
      * longitude using the visitor's IP address (if configured to do so).
      *
      * Allowed only for Admin/Super User, must be used along with setTokenAuth().
@@ -493,16 +568,22 @@ class PiwikTracker
      * @param string $domain (optional) Set first-party cookie domain.
      *  Accepted values: example.com, *.example.com (same as .example.com) or subdomain.example.com
      * @param string $path (optional) Set first-party cookie path
+     * @param bool $secure (optional) Set secure flag for cookies
+     * @param bool $httpOnly (optional) Set HTTPOnly flag for cookies
+     * @param string $sameSite (optional) Set SameSite flag for cookies
      */
-    public function enableCookies($domain = '', $path = '/')
+    public function enableCookies($domain = '', $path = '/', $secure = false, $httpOnly = false, $sameSite = '')
     {
         $this->configCookiesDisabled = false;
         $this->configCookieDomain = self::domainFixup($domain);
         $this->configCookiePath = $path;
+        $this->configCookieSecure = $secure;
+        $this->configCookieHTTPOnly = $httpOnly;
+        $this->configCookieSameSite = $sameSite;
     }
 
     /**
-     * If image response is disabled Piwik will respond with a HTTP 204 header instead of responding with a gif.
+     * If image response is disabled Matomo will respond with a HTTP 204 header instead of responding with a gif.
      */
     public function disableSendImageResponse()
     {
@@ -517,7 +598,7 @@ class PiwikTracker
         if (strlen($domain) > 0) {
             $dl = strlen($domain) - 1;
             // remove trailing '.'
-            if ($domain{$dl} === '.') {
+            if ($domain[$dl] === '.') {
                 $domain = substr($domain, 0, $dl);
             }
             // remove leading '*'
@@ -536,7 +617,7 @@ class PiwikTracker
      */
     protected function getCookieName($cookieName)
     {
-        // NOTE: If the cookie name is changed, we must also update the method in piwik.js with the same name.
+        // NOTE: If the cookie name is changed, we must also update the method in matomo.js with the same name.
         $hash = substr(
             sha1(
                 ($this->configCookieDomain == '' ? self::getCurrentHost() : $this->configCookieDomain) . $this->configCookiePath
@@ -681,6 +762,7 @@ class PiwikTracker
      * @param float|int $price (optional) Individual product price (supports integer and decimal prices)
      * @param int $quantity (optional) Product quantity. If not specified, will default to 1 in the Reports
      * @throws Exception
+     * @return $this
      */
     public function addEcommerceItem($sku, $name = '', $category = '', $price = 0.0, $quantity = 1)
     {
@@ -691,6 +773,7 @@ class PiwikTracker
         $price = $this->forceDotAsSeparatorForDecimalPoint($price);
 
         $this->ecommerceItems[] = array($sku, $name, $category, $price, $quantity);
+        return $this;
     }
 
     /**
@@ -746,12 +829,12 @@ class PiwikTracker
      * Tracks an Ecommerce order.
      *
      * If the Ecommerce order contains items (products), you must call first the addEcommerceItem() for each item in the order.
-     * All revenues (grandTotal, subTotal, tax, shipping, discount) will be individually summed and reported in Piwik reports.
+     * All revenues (grandTotal, subTotal, tax, shipping, discount) will be individually summed and reported in Matomo reports.
      * Only the parameters $orderId and $grandTotal are required.
      *
      * @param string|int $orderId (required) Unique Order ID.
      *                This will be used to count this order only once in the event the order page is reloaded several times.
-     *                orderId must be unique for each transaction, even on different days, or the transaction will not be recorded by Piwik.
+     *                orderId must be unique for each transaction, even on different days, or the transaction will not be recorded by Matomo.
      * @param float $grandTotal (required) Grand Total revenue of the transaction (including tax, shipping, etc.)
      * @param float $subTotal (optional) Sub total amount, typically the sum of items prices for all items in this order (before Tax and Shipping costs are applied)
      * @param float $tax (optional) Tax amount for this order
@@ -794,12 +877,10 @@ class PiwikTracker
      * Sets the current page view as an item (product) page view, or an Ecommerce Category page view.
      *
      * This must be called before doTrackPageView() on this product/category page.
-     * It will set 3 custom variables of scope "page" with the SKU, Name and Category for this page view.
-     * Note: Custom Variables of scope "page" slots 3, 4 and 5 will be used.
      *
      * On a category page, you may set the parameter $category only and set the other parameters to false.
      *
-     * Tracking Product/Category page views will allow Piwik to report on Product & Categories
+     * Tracking Product/Category page views will allow Matomo to report on Product & Categories
      * conversion rates (Conversion rate = Ecommerce orders containing this product or category / Visits to the product or category)
      *
      * @param string $sku Product SKU being viewed
@@ -811,6 +892,8 @@ class PiwikTracker
      */
     public function setEcommerceView($sku = '', $name = '', $category = '', $price = 0.0)
     {
+        $this->ecommerceView = [];
+
         if (!empty($category)) {
             if (is_array($category)) {
                 $category = json_encode($category);
@@ -818,12 +901,12 @@ class PiwikTracker
         } else {
             $category = "";
         }
-        $this->pageCustomVar[self::CVAR_INDEX_ECOMMERCE_ITEM_CATEGORY] = array('_pkc', $category);
+        $this->ecommerceView['_pkc'] = $category;
 
         if (!empty($price)) {
             $price = (float)$price;
             $price = $this->forceDotAsSeparatorForDecimalPoint($price);
-            $this->pageCustomVar[self::CVAR_INDEX_ECOMMERCE_ITEM_PRICE] = array('_pkp', $price);
+            $this->ecommerceView['_pkp'] = $price;
         }
 
         // On a category page, do not record "Product name not defined"
@@ -831,17 +914,17 @@ class PiwikTracker
             return $this;
         }
         if (!empty($sku)) {
-            $this->pageCustomVar[self::CVAR_INDEX_ECOMMERCE_ITEM_SKU] = array('_pks', $sku);
+            $this->ecommerceView['_pks'] = $sku;
         }
         if (empty($name)) {
             $name = "";
         }
-        $this->pageCustomVar[self::CVAR_INDEX_ECOMMERCE_ITEM_NAME] = array('_pkn', $name);
+        $this->ecommerceView['_pkn'] = $name;
         return $this;
     }
 
     /**
-     * Force the separator for decimal point to be a dot. See https://github.com/piwik/piwik/issues/6435
+     * Force the separator for decimal point to be a dot. See https://github.com/matomo-org/matomo/issues/6435
      * If for instance a German locale is used it would be a comma otherwise.
      *
      * @param  float|string $value
@@ -889,7 +972,6 @@ class PiwikTracker
         }
         $url = $this->getUrlTrackEcommerce($grandTotal, $subTotal, $tax, $shipping, $discount);
         $url .= '&ec_id=' . urlencode($orderId);
-        $this->ecommerceLastOrderTimestamp = $this->getTimestamp();
 
         return $url;
     }
@@ -942,8 +1024,8 @@ class PiwikTracker
      * Builds URL to track a page view.
      *
      * @see doTrackPageView()
-     * @param string $documentTitle Page view name as it will appear in Piwik reports
-     * @return string URL to piwik.php with all parameters set to track the pageview
+     * @param string $documentTitle Page view name as it will appear in Matomo reports
+     * @return string URL to matomo.php with all parameters set to track the pageview
      */
     public function getUrlTrackPageView($documentTitle = '')
     {
@@ -963,7 +1045,7 @@ class PiwikTracker
      * @param string $action The Event's Action (Play, Pause, Duration, Add Playlist, Downloaded, Clicked...)
      * @param string|bool $name (optional) The Event's object Name (a particular Movie name, or Song name, or File name...)
      * @param float|bool $value (optional) The Event's value
-     * @return string URL to piwik.php with all parameters set to track the pageview
+     * @return string URL to matomo.php with all parameters set to track the pageview
      * @throws
      */
     public function getUrlTrackEvent($category, $action, $name = false, $value = false)
@@ -998,7 +1080,7 @@ class PiwikTracker
      * @param string $contentPiece The actual content. For instance the path to an image, video, audio, any text
      * @param string|false $contentTarget (optional) The target of the content. For instance the URL of a landing page.
      * @throws Exception In case $contentName is empty
-     * @return string URL to piwik.php with all parameters set to track the pageview
+     * @return string URL to matomo.php with all parameters set to track the pageview
      */
     public function getUrlTrackContentImpression($contentName, $contentPiece, $contentTarget)
     {
@@ -1029,7 +1111,7 @@ class PiwikTracker
      * @param string $contentPiece The actual content. For instance the path to an image, video, audio, any text
      * @param string|false $contentTarget (optional) The target the content leading to when an interaction occurs. For instance the URL of a landing page.
      * @throws Exception In case $interaction or $contentName is empty
-     * @return string URL to piwik.php with all parameters set to track the pageview
+     * @return string URL to matomo.php with all parameters set to track the pageview
      */
     public function getUrlTrackContentInteraction($interaction, $contentName, $contentPiece, $contentTarget)
     {
@@ -1085,7 +1167,7 @@ class PiwikTracker
      * @see doTrackGoal()
      * @param int $idGoal Id Goal to record a conversion
      * @param float $revenue Revenue for this conversion
-     * @return string URL to piwik.php with all parameters set to track the goal conversion
+     * @return string URL to matomo.php with all parameters set to track the goal conversion
      */
     public function getUrlTrackGoal($idGoal, $revenue = 0.0)
     {
@@ -1105,7 +1187,7 @@ class PiwikTracker
      * @see doTrackAction()
      * @param string $actionUrl URL of the download or outlink
      * @param string $actionType Type of the action: 'download' or 'link'
-     * @return string URL to piwik.php with all parameters set to track an action
+     * @return string URL to matomo.php with all parameters set to track an action
      */
     public function getUrlTrackAction($actionUrl, $actionType)
     {
@@ -1117,7 +1199,7 @@ class PiwikTracker
 
     /**
      * Overrides server date and time for the tracking requests.
-     * By default Piwik will track requests for the "current datetime" but this function allows you
+     * By default Matomo will track requests for the "current datetime" but this function allows you
      * to track visits in the past. All times are in UTC.
      *
      * Allowed only for Admin/Super User, must be used along with setTokenAuth()
@@ -1133,9 +1215,9 @@ class PiwikTracker
     }
 
     /**
-     * Forces Piwik to create a new visit for the tracking request.
+     * Forces Matomo to create a new visit for the tracking request.
      *
-     * By default, Piwik will create a new visit if the last request by this user was more than 30 minutes ago.
+     * By default, Matomo will create a new visit if the last request by this user was more than 30 minutes ago.
      * If you call setForceNewVisit() before calling doTrack*, then a new visit will be created for this request.
      * @return $this
      */
@@ -1170,10 +1252,6 @@ class PiwikTracker
      */
     public function setUserId($userId)
     {
-        if ($userId === false) {
-            $this->setNewVisitorId();
-            return $this;
-        }
         if ($userId === '') {
             throw new Exception("User ID cannot be empty.");
         }
@@ -1182,7 +1260,7 @@ class PiwikTracker
     }
 
     /**
-     * Hash function used internally by Piwik to hash a User ID into the Visitor ID.
+     * Hash function used internally by Matomo to hash a User ID into the Visitor ID.
      *
      * Note: matches implementation of Tracker\Request->getUserIdHashed()
      *
@@ -1196,15 +1274,12 @@ class PiwikTracker
 
     /**
      * Forces the requests to be recorded for the specified Visitor ID.
-     * Note: it is recommended to use ->setUserId($userId); instead.
      *
-     * Rather than letting Piwik attribute the user with a heuristic based on IP and other user fingeprinting attributes,
+     * Rather than letting Matomo attribute the user with a heuristic based on IP and other user fingeprinting attributes,
      * force the action to be recorded for a particular visitor.
      *
-     * If you use both setVisitorId and setUserId, setUserId will take precedence.
      * If not set, the visitor ID will be fetched from the 1st party cookie, or will be set to a random UUID.
      *
-     * @deprecated We recommend to use  ->setUserId($userId).
      * @param string $visitorId 16 hexadecimal characters visitor ID, eg. "33c31e01394bdc63"
      * @return $this
      * @throws Exception
@@ -1228,7 +1303,7 @@ class PiwikTracker
     }
 
     /**
-     * If the user initiating the request has the Piwik first party cookie,
+     * If the user initiating the request has the Matomo first party cookie,
      * this function will try and return the ID parsed from this first party cookie (found in $_COOKIE).
      *
      * If you call this function from a server, where the call is triggered by a cron or script
@@ -1241,9 +1316,6 @@ class PiwikTracker
      */
     public function getVisitorId()
     {
-        if (!empty($this->userId)) {
-            return $this->getUserIdHashed($this->userId);
-        }
         if (!empty($this->forcedVisitorId)) {
             return $this->forcedVisitorId;
         }
@@ -1298,16 +1370,11 @@ class PiwikTracker
         if (strlen($parts[0]) != self::LENGTH_VISITOR_ID) {
             return false;
         }
+
         /* $this->cookieVisitorId provides backward compatibility since getVisitorId()
-        didn't change any existing VisitorId value */
+didn't change any existing VisitorId value */
         $this->cookieVisitorId = $parts[0];
         $this->createTs = $parts[1];
-        $this->visitCount = (int)$parts[2];
-        $this->currentVisitTs = $parts[3];
-        $this->lastVisitTs = $parts[4];
-        if (isset($parts[5])) {
-            $this->ecommerceLastOrderTimestamp = $parts[5];
-        }
 
         return true;
     }
@@ -1331,7 +1398,7 @@ class PiwikTracker
      *
      * @return string JSON Encoded string containing the Referrer information for Goal conversion attribution.
      *                Will return false if the cookie could not be found
-     * @see Piwik.js getAttributionInfo()
+     * @see matomo.js getAttributionInfo()
      */
     public function getAttributionInfo()
     {
@@ -1390,7 +1457,7 @@ class PiwikTracker
 
     /**
      * Sets if the browser supports cookies
-     * This is reported in "List of plugins" report in Piwik.
+     * This is reported in "List of plugins" report in Matomo.
      *
      * @param bool $bool
      * @return $this
@@ -1417,42 +1484,36 @@ class PiwikTracker
      *
      * @param bool $flash
      * @param bool $java
-     * @param bool $director
      * @param bool $quickTime
      * @param bool $realPlayer
      * @param bool $pdf
      * @param bool $windowsMedia
-     * @param bool $gears
      * @param bool $silverlight
      * @return $this
      */
     public function setPlugins(
         $flash = false,
         $java = false,
-        $director = false,
         $quickTime = false,
         $realPlayer = false,
         $pdf = false,
         $windowsMedia = false,
-        $gears = false,
         $silverlight = false
     )
     {
         $this->plugins =
             '&fla=' . (int)$flash .
             '&java=' . (int)$java .
-            '&dir=' . (int)$director .
             '&qt=' . (int)$quickTime .
             '&realp=' . (int)$realPlayer .
             '&pdf=' . (int)$pdf .
             '&wma=' . (int)$windowsMedia .
-            '&gears=' . (int)$gears .
             '&ag=' . (int)$silverlight;
         return $this;
     }
 
     /**
-     * By default, PiwikTracker will read first party cookies
+     * By default, MatomoTracker will read first party cookies
      * from the request and write updated cookies in the response (using setrawcookie).
      * This can be disabled by calling this function.
      */
@@ -1463,7 +1524,7 @@ class PiwikTracker
 
     /**
      * Returns the maximum number of seconds the tracker will spend waiting for a response
-     * from Piwik. Defaults to 600 seconds.
+     * from Matomo. Defaults to 600 seconds.
      */
     public function getRequestTimeout()
     {
@@ -1472,7 +1533,7 @@ class PiwikTracker
 
     /**
      * Sets the maximum number of seconds that the tracker will spend waiting for a response
-     * from Piwik.
+     * from Matomo.
      *
      * @param int $timeout
      * @return $this
@@ -1487,9 +1548,24 @@ class PiwikTracker
         $this->requestTimeout = $timeout;
         return $this;
     }
+	
+	/**
+     * Sets the request method to POST, which is recommended when using setTokenAuth()
+     * to prevent the token from being recorded in server logs. Avoid using redirects
+     * when using POST to prevent the loss of POST values. When using Log Analytics,
+     * be aware that POST requests are not parseable/replayable.
+     *
+     * @param string $method Either 'POST' or 'GET'
+     * @return $this
+     */
+    public function setRequestMethodNonBulk($method)
+    {
+        $this->requestMethod = strtoupper($method) === 'POST' ? 'POST' : 'GET';
+        return $this;
+    }
 
     /**
-     * If a proxy is needed to look up the address of the Piwik site, set it with this
+     * If a proxy is needed to look up the address of the Matomo site, set it with this
      * @param string $proxy IP as string, for example "173.234.92.107"
      * @param int $proxyPort
      */
@@ -1532,13 +1608,45 @@ class PiwikTracker
                 . (!empty($this->userAgent) ? ('&ua=' . urlencode($this->userAgent)) : '')
                 . (!empty($this->acceptLanguage) ? ('&lang=' . urlencode($this->acceptLanguage)) : '');
 
-            // Clear custom variables so they don't get copied over to other users in the bulk request
+            // Clear custom variables & dimensions so they don't get copied over to other users in the bulk request
             $this->clearCustomVariables();
+            $this->clearCustomDimensions();
             $this->clearCustomTrackingParameters();
             $this->userAgent = false;
             $this->acceptLanguage = false;
 
             return true;
+        }
+
+        $forcePostUrlEncoded = false;
+        if (!$this->doBulkRequests) {
+            if (strtoupper($this->requestMethod) === 'POST') {
+                // POST ALL parameters and have no GET parameters
+                $urlParts = explode('?', $url);
+
+                $url = $urlParts[0];
+                $data = $urlParts[1];
+                $forcePostUrlEncoded = true;
+
+                $method = 'POST';
+            }
+
+            if (!empty($this->token_auth)) {
+                $appendTokenString = '&token_auth=' . urlencode($this->token_auth);
+
+                if (empty($this->requestMethod) || $method === 'POST') {
+                    // Only post token_auth but use GET URL parameters for everything else
+                    $forcePostUrlEncoded = true;
+                    if (empty($data)) {
+                        $data = '';
+                    }
+                    $data .= $appendTokenString;
+                    $data = ltrim($data, '&'); // when no request method set we don't want it to start with '&'
+                } elseif (!empty($this->token_auth)) {
+                    // Use GET for all URL parameters
+                    $url .= $appendTokenString;
+                }
+            }
         }
 
         $proxy = $this->getProxy();
@@ -1554,6 +1662,10 @@ class PiwikTracker
                     'Accept-Language: ' . $this->acceptLanguage,
                 ),
             );
+
+            if ($method === 'GET') {
+                $options[CURLOPT_FOLLOWLOCATION] = true;
+            }
 
             if (defined('PATH_TO_CERTIFICATES_FILE')) {
                 $options[CURLOPT_CAINFO] = PATH_TO_CERTIFICATES_FILE;
@@ -1572,7 +1684,15 @@ class PiwikTracker
             }
 
             // only supports JSON data
-            if (!empty($data)) {
+            if (!empty($data) && $forcePostUrlEncoded) {
+                $options[CURLOPT_HTTPHEADER][] = 'Content-Type: application/x-www-form-urlencoded';
+                $options[CURLOPT_POSTFIELDS] = $data;
+                $options[CURLOPT_POST] = true;
+                if (defined('CURL_REDIR_POST_ALL')) {
+                    $options[CURLOPT_POSTREDIR] = CURL_REDIR_POST_ALL;
+                    $options[CURLOPT_FOLLOWLOCATION] = true;
+                }
+            } elseif (!empty($data)) {
                 $options[CURLOPT_HTTPHEADER][] = 'Content-Type: application/json';
                 $options[CURLOPT_HTTPHEADER][] = 'Expect:';
                 $options[CURLOPT_POSTFIELDS] = $data;
@@ -1590,6 +1710,11 @@ class PiwikTracker
             ob_end_clean();
             $header = '';
             $content = '';
+            
+            if ($response === false) {
+                throw new \RuntimeException(curl_error($ch));
+            }
+            
             if (!empty($response)) {
                 list($header, $content) = explode("\r\n\r\n", $response, $limitCount = 2);
             }
@@ -1602,7 +1727,7 @@ class PiwikTracker
                     'method' => $method,
                     'user_agent' => $this->userAgent,
                     'header' => "Accept-Language: " . $this->acceptLanguage . "\r\n",
-                    'timeout' => $this->requestTimeout, // PHP 5.2.1
+                    'timeout' => $this->requestTimeout,
                 ),
             );
 
@@ -1611,7 +1736,10 @@ class PiwikTracker
             }
 
             // only supports JSON data
-            if (!empty($data)) {
+            if (!empty($data) && $forcePostUrlEncoded) {
+                $stream_options['http']['header'] .= "Content-Type: application/x-www-form-urlencoded \r\n";
+                $stream_options['http']['content'] = $data;
+            } elseif (!empty($data)) {
                 $stream_options['http']['header'] .= "Content-Type: application/json \r\n";
                 $stream_options['http']['content'] = $data;
             }
@@ -1643,20 +1771,21 @@ class PiwikTracker
     }
 
     /**
-     * Returns the base URL for the piwik server.
+     * Returns the base URL for the Matomo server.
      */
     protected function getBaseUrl()
     {
         if (empty(self::$URL)) {
             throw new Exception(
-                'You must first set the Piwik Tracker URL by calling
-                 PiwikTracker::$URL = \'http://your-website.org/piwik/\';'
+                'You must first set the Matomo Tracker URL by calling
+                 MatomoTracker::$URL = \'http://your-website.org/matomo/\';'
             );
         }
-        if (strpos(self::$URL, '/piwik.php') === false
-            && strpos(self::$URL, '/proxy-piwik.php') === false
+        if (strpos(self::$URL, '/matomo.php') === false
+            && strpos(self::$URL, '/proxy-matomo.php') === false
         ) {
-            self::$URL .= '/piwik.php';
+            self::$URL = rtrim(self::$URL, '/');
+            self::$URL .= '/matomo.php';
         }
 
         return self::$URL;
@@ -1674,8 +1803,19 @@ class PiwikTracker
             $customFields = '&' . http_build_query($this->customParameters, '', '&');
         }
 
-        $url = $this->getBaseUrl() .
-            '?idsite=' . $idSite .
+        $customDimensions = '';
+        if (!empty($this->customDimensions)) {
+            $customDimensions = '&' . http_build_query($this->customDimensions, '', '&');
+        }
+
+        $baseUrl = $this->getBaseUrl();
+        $start = '?';
+        if (strpos($baseUrl, '?') !== false) {
+            $start = '&';
+        }
+
+        $url = $baseUrl . $start .
+            'idsite=' . $idSite .
             '&rec=1' .
             '&apiv=' . self::VERSION .
             '&r=' . substr(strval(mt_rand()), 2, 6) .
@@ -1686,19 +1826,13 @@ class PiwikTracker
             (!empty($_GET['KEY']) ? '&KEY=' . @urlencode($_GET['KEY']) : '') .
 
             // Only allowed for Admin/Super User, token_auth required,
-            (!empty($this->ip) ? '&cip=' . $this->ip : '') .
+            ((!empty($this->ip) && !empty($this->token_auth)) ? '&cip=' . $this->ip : '') .
             (!empty($this->userId) ? '&uid=' . urlencode($this->userId) : '') .
             (!empty($this->forcedDatetime) ? '&cdt=' . urlencode($this->forcedDatetime) : '') .
             (!empty($this->forcedNewVisit) ? '&new_visit=1' : '') .
-            ((!empty($this->token_auth) && !$this->doBulkRequests) ?
-                '&token_auth=' . urlencode($this->token_auth) : '') .
 
             // Values collected from cookie
             '&_idts=' . $this->createTs .
-            '&_idvc=' . $this->visitCount .
-            (!empty($this->lastVisitTs) ? '&_viewts=' . $this->lastVisitTs : '') .
-            (!empty($this->ecommerceLastOrderTimestamp) ?
-                '&_ects=' . urlencode($this->ecommerceLastOrderTimestamp) : '') .
 
             // These parameters are set by the JS, but optional when using API
             (!empty($this->plugins) ? $this->plugins : '') .
@@ -1712,7 +1846,6 @@ class PiwikTracker
             (!empty($this->visitorCustomVar) ? '&_cvar=' . urlencode(json_encode($this->visitorCustomVar)) : '') .
             (!empty($this->pageCustomVar) ? '&cvar=' . urlencode(json_encode($this->pageCustomVar)) : '') .
             (!empty($this->eventCustomVar) ? '&e_cvar=' . urlencode(json_encode($this->eventCustomVar)) : '') .
-            (!empty($this->generationTime) ? '&gt_ms=' . ((int)$this->generationTime) : '') .
             (!empty($this->forcedVisitorId) ? '&cid=' . $this->forcedVisitorId : '&_id=' . $this->getVisitorId()) .
 
             // URL parameters
@@ -1740,16 +1873,32 @@ class PiwikTracker
             (!empty($this->city) ? '&city=' . urlencode($this->city) : '') .
             (!empty($this->lat) ? '&lat=' . urlencode($this->lat) : '') .
             (!empty($this->long) ? '&long=' . urlencode($this->long) : '') .
-            $customFields .
+            $customFields . $customDimensions .
             (!$this->sendImageResponse ? '&send_image=0' : '') .
 
             // DEBUG
             $this->DEBUG_APPEND_URL;
 
+        if (!empty($this->idPageview)) {
+            $url .=
+                ($this->networkTime !== false ? '&pf_net=' . ((int)$this->networkTime) : '') .
+                ($this->serverTime !== false ? '&pf_srv=' . ((int)$this->serverTime) : '') .
+                ($this->transferTime !== false ? '&pf_tfr=' . ((int)$this->transferTime) : '') .
+                ($this->domProcessingTime !== false ? '&pf_dm1=' . ((int)$this->domProcessingTime) : '') .
+                ($this->domCompletionTime !== false ? '&pf_dm2=' . ((int)$this->domCompletionTime) : '') .
+                ($this->onLoadTime !== false ? '&pf_onl=' . ((int)$this->onLoadTime) : '');
+            $this->clearPerformanceTimings();
+        }
+
+        foreach ($this->ecommerceView as $param => $value) {
+            $url .= '&' . $param . '=' . urlencode($value);
+        }
 
         // Reset page level custom variables after this page view
+        $this->ecommerceView = array();
         $this->pageCustomVar = array();
         $this->eventCustomVar = array();
+        $this->clearCustomDimensions();
         $this->clearCustomTrackingParameters();
 
         // force new visit only once, user must call again setForceNewVisit()
@@ -1776,7 +1925,7 @@ class PiwikTracker
         }
         $name = $this->getCookieName($name);
 
-        // Piwik cookie names use dots separators in piwik.js,
+        // Matomo cookie names use dots separators in matomo.js,
         // but PHP Replaces . with _ http://www.php.net/manual/en/language.variables.predefined.php#72571
         $name = str_replace('.', '_', $name);
         foreach ($_COOKIE as $cookieName => $cookieValue) {
@@ -1809,11 +1958,13 @@ class PiwikTracker
                 }
             }
         }
-        if (empty($url)) {
+        if (empty($url) && isset($_SERVER['SCRIPT_NAME'])) {
             $url = $_SERVER['SCRIPT_NAME'];
+        } elseif (empty($url)) {
+        	$url = '/';
         }
 
-        if ($url[0] !== '/') {
+        if (!empty($url) && $url[0] !== '/') {
             $url = '/' . $url;
         }
 
@@ -1888,7 +2039,7 @@ class PiwikTracker
     }
 
     /**
-     * Sets the first party cookies as would the piwik.js
+     * Sets the first party cookies as would the matomo.js
      * All cookies are supported: 'id' and 'ses' and 'ref' and 'cvar' cookies.
      * @return $this
      */
@@ -1912,9 +2063,7 @@ class PiwikTracker
         $this->setCookie('ses', '*', $this->configSessionCookieTimeout);
 
         // Set the 'id' cookie
-        $visitCount = $this->visitCount + 1;
-        $cookieValue = $this->getVisitorId() . '.' . $this->createTs . '.' . $visitCount . '.' . $this->currentTs .
-            '.' . $this->lastVisitTs . '.' . $this->ecommerceLastOrderTimestamp;
+        $cookieValue = $this->getVisitorId() . '.' . $this->createTs;
         $this->setCookie('id', $cookieValue, $this->configVisitorCookieTimeout);
 
         // Set the 'cvar' cookie
@@ -1925,7 +2074,7 @@ class PiwikTracker
     /**
      * Sets a first party cookie to the client to improve dual JS-PHP tracking.
      *
-     * This replicates the piwik.js tracker algorithms for consistency and better accuracy.
+     * This replicates the matomo.js tracker algorithms for consistency and better accuracy.
      *
      * @param $cookieName
      * @param $cookieValue
@@ -1936,13 +2085,15 @@ class PiwikTracker
     {
         $cookieExpire = $this->currentTs + $cookieTTL;
         if (!headers_sent()) {
-            setcookie(
-                $this->getCookieName($cookieName),
-                $cookieValue,
-                $cookieExpire,
-                $this->configCookiePath,
-                $this->configCookieDomain
-            );
+            $header = 'Set-Cookie: ' . rawurlencode($this->getCookieName($cookieName)) . '=' . rawurlencode($cookieValue)
+                . (empty($cookieExpire) ? '' : '; expires=' . gmdate('D, d-M-Y H:i:s', $cookieExpire) . ' GMT')
+                . (empty($this->configCookiePath) ? '' : '; path=' . $this->configCookiePath)
+                . (empty($this->configCookieDomain) ? '' : '; domain=' . rawurlencode($this->configCookieDomain))
+                . (!$this->configCookieSecure ? '' : '; secure')
+                . (!$this->configCookieHTTPOnly ? '' : '; HttpOnly')
+                . (!$this->configCookieSameSite ? '' : '; SameSite=' . rawurlencode($this->configCookieSameSite));
+
+            header($header, false);
         }
         return $this;
     }
@@ -1995,7 +2146,7 @@ class PiwikTracker
     /**
      * Reads incoming tracking server cookies.
      *
-     * @param $headers Array with HTTP response headers as values
+     * @param array $headers Array with HTTP response headers as values
      */
     protected function parseIncomingCookies($headers)
     {
@@ -2027,7 +2178,7 @@ class PiwikTracker
  * @param string $documentTitle
  * @return string
  */
-function Piwik_getUrlTrackPageView($idSite, $documentTitle = '')
+function Matomo_getUrlTrackPageView($idSite, $documentTitle = '')
 {
     $tracker = new PiwikTracker($idSite);
 
@@ -2042,7 +2193,7 @@ function Piwik_getUrlTrackPageView($idSite, $documentTitle = '')
  * @param float $revenue
  * @return string
  */
-function Piwik_getUrlTrackGoal($idSite, $idGoal, $revenue = 0.0)
+function Matomo_getUrlTrackGoal($idSite, $idGoal, $revenue = 0.0)
 {
     $tracker = new PiwikTracker($idSite);
 

--- a/classes/TrackerHelper.php
+++ b/classes/TrackerHelper.php
@@ -180,22 +180,6 @@ class TrackerHelper
 
     }
 
-    // if(isset($_COOKIE['CookieConsent'])) {
-    //   $consent = $_COOKIE['CookieConsent'];
-    //   if($consent == 0 || $consent == "0"){
-    //     $piwikTracker->disableCookieSupport();
-    //   } else {
-    //       $domain = "";
-    //       $path = "/";
-    //       $secure = "true";
-    //       $httpOnly = "true";
-    //       $sameSite = "Strict";
-    //       $piwikTracker->enableCookies($domain, $path, $secure, $httpOnly, $sameSite);
-    //     }
-    // } else {
-    //   $piwikTracker->disableCookieSupport();
-    // }
-
     //setip mandatory if behind a proxy!
     $ip = $this->getClientIp();
     $piwikTracker->setIp("$ip");

--- a/classes/TrackerHelper.php
+++ b/classes/TrackerHelper.php
@@ -87,6 +87,45 @@ class TrackerHelper
 
   }
 
+  /**
+   * Get consent options
+  **/
+  public function getConsentSettings(){
+
+    $consentModeEnable = Settings::get('consent_mode', false);
+    if(!$consentModeEnable){
+      return null;
+    }
+
+    $disableCookies = false;
+    $disableCookies = Settings::get('disable_cookies', false);
+
+    $allowCookies = Settings::get('allow_cookies', false);
+
+    if(isset($allowCookies)){
+      $consentCookieName = Settings::get('consent_cookie_name', false);
+  
+      $consentCookieValue = Settings::get('consent_cookie_value', false);
+  
+      $httpCookies = Settings::get('http_cookies', false);
+  
+      $secureCookies = Settings::get('secure_cookies', false);
+  
+      $samesiteCookies = Settings::get('samesite_cookies', false);
+    } 
+
+    return [
+      'disableCookies' => $disableCookies,
+      'allowCookies' => $allowCookies,
+      'consentCookieName' => $consentCookieName,
+      'consentCookieValue' => $consentCookieValue,
+      'httpCookies' => $httpCookies,
+      'secureCookies' => $secureCookies,
+      'samesiteCookies' => $samesiteCookies
+    ];
+
+  }
+
   public function initTracker(){
 
     if( BackendAuth::check() === true ){ return null; }
@@ -95,11 +134,67 @@ class TrackerHelper
     $settings = $this->getSettings();
     if($settings === null){ return null; }
 
-
-
     PiwikTracker::$URL = $settings['urlSite'];
     $piwikTracker = new PiwikTracker( $idSite = $settings['idSite'] );
     $piwikTracker->setTokenAuth($settings['tokenAuth']);
+
+    // get consent settings and disable or enable cookies accordingly
+    $consentSettings = $this->getConsentSettings();
+    if ($consentSettings != null){
+
+      // if Consent Mode is enabled but cookies are not, disable them
+      if ($consentSettings['disableCookies']){
+
+        $piwikTracker->disableCookieSupport();
+
+      } 
+      // otherwise set cookies according to settings
+      else {
+
+        $cookieName = $consentSettings['consentCookieName'];
+        $cookieValue = $consentSettings['consentCookieValue'];
+        
+        if(isset($_COOKIE[$cookieName]) and $consentSettings['allowCookies'] == true) {
+  
+          $consent = $_COOKIE[$cookieName];
+  
+          if($consent != $cookieValue){
+  
+            $piwikTracker->disableCookieSupport();
+  
+          } 
+          else {
+  
+            $domain = "";
+            $path = "/";
+            $secure = $consentSettings['httpCookies'];
+            $httpOnly = $consentSettings['secureCookies'];
+            $sameSite = ($consentSettings['samesiteCookies'] == true ? "Strict" : "None");
+            $piwikTracker->enableCookies($domain, $path, $secure, $httpOnly, $sameSite);
+  
+          }
+        } else {
+          $piwikTracker->disableCookieSupport();
+        }
+      }
+
+    }
+
+    // if(isset($_COOKIE['CookieConsent'])) {
+    //   $consent = $_COOKIE['CookieConsent'];
+    //   if($consent == 0 || $consent == "0"){
+    //     $piwikTracker->disableCookieSupport();
+    //   } else {
+    //       $domain = "";
+    //       $path = "/";
+    //       $secure = "true";
+    //       $httpOnly = "true";
+    //       $sameSite = "Strict";
+    //       $piwikTracker->enableCookies($domain, $path, $secure, $httpOnly, $sameSite);
+    //     }
+    // } else {
+    //   $piwikTracker->disableCookieSupport();
+    // }
 
     //setip mandatory if behind a proxy!
     $ip = $this->getClientIp();

--- a/lang/en/lang.php
+++ b/lang/en/lang.php
@@ -12,6 +12,29 @@
       'site_id_description' => 'Website id: https://matomo.org/faq/general/faq_19212/',
       'token' => 'Token',
       'token_description' => 'Authentication token provided by Matomo',
+      'consent' => [
+        'consent_mode' => 'Activate Consent Mode',
+        'disable_cookies' => 'Deactivate cookies and use only fingerprint (settings below will be ignored if checked)',
+        'allow_cookies' => 'Allow cookies after consent',
+        'http_cookies' => 'Set server-side cookies as "httpOnly"',
+        'secure_cookies' => 'Set server-side cookies as "secure"',
+        'samesite_cookies' => 'Set SameSite attribute for server-side cookies to "Strict"',
+        'consent_cookie_name' => 'Name of the cookie where consent is stored',
+        'consent_cookie_value' => 'Value of the cookie  after consent was granted',
+        'comments' => [
+          'disable_comment' => 'Disable all cookies by the MatomoPhpTracker and use only fingerprinting: https://matomo.org/faq/general/faq_157/.',
+          'enable_comment' => 'Enter a cookie containing the consent information and let Matomo set cookies based on this info.',
+        ],
+      ],
+      'section' => [
+        'section_consent' => 'Configure cookie behavior',
+        'section_fingerprint' => 'Use the MatomoPhpTracker with fingerprint identification of the user only',
+        'section_cookie' => 'Configure server-side cookies set by MatomoPhpTracker',
+      ],
+      'tabs' => [
+        'config' => 'Configuration',
+        'consent' => 'Consent'
+      ],
     ],
 
     'components' => [

--- a/models/settings/fields.yaml
+++ b/models/settings/fields.yaml
@@ -1,19 +1,123 @@
-fields:
-  is_enable:
-    label: acte.matomophptracker::lang.settings.enable_tracker
-    span: full
-    type: switch
-  url:
-    label: acte.matomophptracker::lang.settings.matomo_url
-    span: auto
-    type: text
-  siteid:
-    label: acte.matomophptracker::lang.settings.site_id
-    span: auto
-    type: number
-    comment: acte.matomophptracker::lang.settings.site_id_description
-  token:
-    label: acte.matomophptracker::lang.settings.token
-    span: full
-    type: text
-    comment: acte.matomophptracker::lang.settings.token_description
+tabs:
+  fields:
+    is_enable:
+      label: acte.matomophptracker::lang.settings.enable_tracker
+      span: full
+      type: switch
+      tab: acte.matomophptracker::lang.settings.tabs.config
+    url:
+      label: acte.matomophptracker::lang.settings.matomo_url
+      span: auto
+      type: text
+      tab: acte.matomophptracker::lang.settings.tabs.config
+    siteid:
+      label: acte.matomophptracker::lang.settings.site_id
+      span: auto
+      type: number
+      comment: acte.matomophptracker::lang.settings.site_id_description
+      tab: acte.matomophptracker::lang.settings.tabs.config
+    token:
+      label: acte.matomophptracker::lang.settings.token
+      span: full
+      type: text
+      comment: acte.matomophptracker::lang.settings.token_description
+      tab: acte.matomophptracker::lang.settings.tabs.config
+
+    ## CONSENT
+    
+    section_consent:
+      type: section
+      label: acte.matomophptracker::lang.settings.section.section_consent
+      tab: acte.matomophptracker::lang.settings.tabs.consent
+
+    consent_mode:
+      label: acte.matomophptracker::lang.settings.consent.consent_mode
+      span: full
+      type: switch
+      default: false
+      tab: acte.matomophptracker::lang.settings.tabs.consent
+
+    section_fingerprint:
+      type: section
+      label: acte.matomophptracker::lang.settings.section.section_fingerprint
+      tab: acte.matomophptracker::lang.settings.tabs.consent
+
+    disable_cookies:
+      label: acte.matomophptracker::lang.settings.consent.disable_cookies
+      comment: acte.matomophptracker::lang.settings.consent.comments.disable_comment
+      span: full
+      type: checkbox
+      tab: acte.matomophptracker::lang.settings.tabs.consent
+
+    section_cookie:
+      type: section
+      label: acte.matomophptracker::lang.settings.section.section_cookie
+      tab: acte.matomophptracker::lang.settings.tabs.consent
+      default: false
+
+    allow_cookies:
+      label: acte.matomophptracker::lang.settings.consent.allow_cookies
+      comment: acte.matomophptracker::lang.settings.consent.comments.enable_comment
+      span: full
+      type: checkbox
+      tab: acte.matomophptracker::lang.settings.tabs.consent
+
+    consent_cookie_name:
+      label: acte.matomophptracker::lang.settings.consent.consent_cookie_name
+      comment: Enter the name of the cookie where the user's consent is stored.
+      placeholder: cookie_consent
+      span: storm
+      type: text
+      tab: acte.matomophptracker::lang.settings.tabs.consent
+      cssClass: field-indent col-md-4 
+      trigger:
+          action: show
+          field: allow_cookies
+          condition: checked
+
+    consent_cookie_value:
+      label: acte.matomophptracker::lang.settings.consent.consent_cookie_value
+      comment: Enter the value of the cookie when consent is granted.
+      placeholder: true
+      span: storm
+      type: text
+      tab: acte.matomophptracker::lang.settings.tabs.consent
+      cssClass: field-indent col-md-4 
+      trigger:
+        action: show
+        field: allow_cookies
+        condition: checked
+      
+    http_cookies:
+      label: acte.matomophptracker::lang.settings.consent.http_cookies
+      span: full
+      type: checkbox
+      tab: acte.matomophptracker::lang.settings.tabs.consent
+      cssClass: field-indent
+      trigger:
+        action: show
+        field: allow_cookies
+        condition: checked
+    
+    secure_cookies:
+      label: acte.matomophptracker::lang.settings.consent.secure_cookies
+      span: full
+      type: checkbox
+      tab: acte.matomophptracker::lang.settings.tabs.consent
+      cssClass: field-indent
+      trigger:
+        action: show
+        field: allow_cookies
+        condition: checked
+    
+    samesite_cookies:
+      label: acte.matomophptracker::lang.settings.consent.samesite_cookies
+      span: full
+      type: checkbox
+      tab: acte.matomophptracker::lang.settings.tabs.consent
+      cssClass: field-indent
+      trigger:
+        action: show
+        field: allow_cookies
+        condition: checked
+      


### PR DESCRIPTION
At the moment the MatomoPhpTracker uncontrollably sets normal cookies on the first page view. Due to the recent restrictions of cookies both technically and regulatory it makes sense to add more consent functionality to this plugin. A consent mode was added to deactivate cookies completely as well allow cookies to be set with `secure` and `httpOnly` flags to make them more resistant against ITP [2.3](https://webkit.org/blog/9521/intelligent-tracking-prevention-2-3/).